### PR TITLE
Animation tweek of Switch component.

### DIFF
--- a/Material.Components.Maui/Components/Switch/Switch.cs
+++ b/Material.Components.Maui/Components/Switch/Switch.cs
@@ -6,11 +6,16 @@ using System.Runtime.CompilerServices;
 using System.Windows.Input;
 
 namespace Material.Components.Maui;
-public partial class Switch : SKTouchCanvasView, IView, IOutlineElement, IShapeElement, IStateLayerElement, IRippleElement
+
+public partial class Switch : SKTouchCanvasView, IView, IOutlineElement, IShapeElement, IStateLayerElement,
+    IRippleElement
 {
     #region interface
+
     #region IView
+
     private ControlState controlState = ControlState.Normal;
+
     public ControlState ControlState
     {
         get => this.controlState;
@@ -20,6 +25,7 @@ public partial class Switch : SKTouchCanvasView, IView, IOutlineElement, IShapeE
             this.ChangeVisualState();
         }
     }
+
     protected override void ChangeVisualState()
     {
         var state = this.ControlState switch
@@ -32,77 +38,98 @@ public partial class Switch : SKTouchCanvasView, IView, IOutlineElement, IShapeE
         };
         VisualStateManager.GoToState(this, state);
     }
+
     public void OnPropertyChanged()
     {
         this.InvalidateSurface();
     }
+
     #endregion
 
     #region IOutlineElement
+
     public static readonly BindableProperty OutlineColorProperty = OutlineElement.OutlineColorProperty;
     public static readonly BindableProperty OutlineWidthProperty = OutlineElement.OutlineWidthProperty;
     public static readonly BindableProperty OutlineOpacityProperty = OutlineElement.OutlineOpacityProperty;
+
     public Color OutlineColor
     {
         get => (Color)this.GetValue(OutlineColorProperty);
         set => this.SetValue(OutlineColorProperty, value);
     }
+
     public int OutlineWidth
     {
         get => (int)this.GetValue(OutlineWidthProperty);
         set => this.SetValue(OutlineWidthProperty, value);
     }
+
     public float OutlineOpacity
     {
         get => (float)this.GetValue(OutlineOpacityProperty);
         set => this.SetValue(OutlineOpacityProperty, value);
     }
+
     #endregion
 
     #region IShapeElement
+
     public static readonly BindableProperty ShapeProperty = ShapeElement.ShapeProperty;
+
     public Shape Shape
     {
         get => (Shape)this.GetValue(ShapeProperty);
         set => this.SetValue(ShapeProperty, value);
     }
+
     #endregion
 
     #region IStateLayerElement
+
     public static readonly BindableProperty StateLayerColorProperty = StateLayerElement.StateLayerColorProperty;
     public static readonly BindableProperty StateLayerOpacityProperty = StateLayerElement.StateLayerOpacityProperty;
+
     public Color StateLayerColor
     {
         get => (Color)this.GetValue(StateLayerColorProperty);
         set => this.SetValue(StateLayerColorProperty, value);
     }
+
     public float StateLayerOpacity
     {
         get => (float)this.GetValue(StateLayerOpacityProperty);
         set => this.SetValue(StateLayerOpacityProperty, value);
     }
+
     #endregion
 
     #region IRippleElement
+
     public static readonly BindableProperty RippleColorProperty = RippleElement.RippleColorProperty;
+
     public Color RippleColor
     {
         get => (Color)this.GetValue(RippleColorProperty);
         set => this.SetValue(RippleColorProperty, value);
     }
+
     [EditorBrowsable(EditorBrowsableState.Never)]
     public float RippleSize { get; private set; } = 0f;
+
     [EditorBrowsable(EditorBrowsableState.Never)]
     public float RipplePercent { get; set; } = 0f;
+
     [EditorBrowsable(EditorBrowsableState.Never)]
     public SKPoint TouchPoint { get; set; } = new SKPoint(-1, -1);
+
     #endregion
+
     #endregion
 
     [AutoBindable(OnChanged = nameof(OnCheckedChanged))]
     private readonly bool isChecked;
 
-    [AutoBindable]
+    [AutoBindable] 
     private readonly Color trackColor;
 
     [AutoBindable(DefaultValue = "1f")]
@@ -113,6 +140,9 @@ public partial class Switch : SKTouchCanvasView, IView, IOutlineElement, IShapeE
 
     [AutoBindable(DefaultValue = "1f")]
     private readonly float thumbOpacity;
+
+    [AutoBindable(DefaultValue = "true")]
+    private readonly bool isIconVisible;
 
     [AutoBindable]
     private readonly Color iconColor;
@@ -128,11 +158,9 @@ public partial class Switch : SKTouchCanvasView, IView, IOutlineElement, IShapeE
         this.Command?.Execute(this.CommandParameter ?? this.IsChecked);
     }
 
-    [AutoBindable]
-    private readonly ICommand command;
+    [AutoBindable] private readonly ICommand command;
 
-    [AutoBindable]
-    private readonly object commandParameter;
+    [AutoBindable] private readonly object commandParameter;
 
     public event EventHandler<CheckedChangedEventArgs> CheckedChanged;
 
@@ -155,12 +183,12 @@ public partial class Switch : SKTouchCanvasView, IView, IOutlineElement, IShapeE
         var start = 0f;
         var end = 1f;
         this.animationManager?.Add(new Microsoft.Maui.Animations.Animation(callback: (progress) =>
-        {
-            this.ChangingPercent = start.Lerp(end, progress);
-            this.InvalidateSurface();
-        },
-        duration: 0.25f,
-        easing: Easing.SinInOut));
+            {
+                this.ChangingPercent = start.Lerp(end, progress);
+                this.InvalidateSurface();
+            },
+            duration: 0.75f,
+            easing: Easing.SinInOut));
     }
 
 
@@ -173,25 +201,26 @@ public partial class Switch : SKTouchCanvasView, IView, IOutlineElement, IShapeE
         var end = 1f;
 
         this.animationManager?.Add(new Microsoft.Maui.Animations.Animation(callback: (progress) =>
-        {
-            this.RipplePercent = start.Lerp(end, progress);
-            this.InvalidateSurface();
-        },
-        duration: 0.35f,
-        easing: Easing.SinInOut,
-        finished: () =>
-        {
-            if (this.ControlState != ControlState.Pressed)
             {
-                this.RipplePercent = 0;
+                this.RipplePercent = start.Lerp(end, progress);
                 this.InvalidateSurface();
-            }
-        }));
+            },
+            duration: 0.35f,
+            easing: Easing.SinInOut,
+            finished: () =>
+            {
+                if (this.ControlState != ControlState.Pressed)
+                {
+                    this.RipplePercent = 0;
+                    this.InvalidateSurface();
+                }
+            }));
     }
 
     protected override void OnPaintSurface(SKPaintSurfaceEventArgs e)
     {
-        var bounds = new SKRect(e.Info.Rect.Left + 8, e.Info.Rect.Top + 8, e.Info.Rect.Right - 8, e.Info.Rect.Bottom - 8);
+        var bounds = new SKRect(e.Info.Rect.Left + 8, e.Info.Rect.Top + 8, e.Info.Rect.Right - 8,
+            e.Info.Rect.Bottom - 8);
         this.drawable.Draw(e.Surface.Canvas, bounds);
     }
 

--- a/Material.Components.Maui/Components/Switch/SwitchDrawable.cs
+++ b/Material.Components.Maui/Components/Switch/SwitchDrawable.cs
@@ -1,7 +1,11 @@
-﻿namespace Material.Components.Maui.Core;
+﻿using Microsoft.Maui.Animations;
+
+namespace Material.Components.Maui.Core;
+
 internal class SwitchDrawable
 {
     private readonly Switch view;
+
     public SwitchDrawable(Switch view)
     {
         this.view = view;
@@ -12,14 +16,18 @@ internal class SwitchDrawable
         var lx = 24;
         var rx = bounds.Right - 16;
         var offX = rx - lx;
-        var cx = this.view.IsChecked ? lx + (this.view.ChangingPercent * offX) : rx - (this.view.ChangingPercent * offX);
+        var cx = this.GetThumbX(lx, rx, offX);
         var cy = 24;
         canvas.Clear();
         this.DrawTrack(canvas, bounds);
         this.DrawOutline(canvas, bounds);
         this.DrawStateLayer(canvas, cx, cy);
         this.DrawThumb(canvas, cx, cy);
-        this.DrawIcon(canvas, cx, cy);
+        if (this.view.IsIconVisible)
+        {
+            this.DrawIcon(canvas, cx, cy);
+        }
+
         this.DrawRippleEffect(canvas, bounds, cx, cy);
     }
 
@@ -30,8 +38,7 @@ internal class SwitchDrawable
         var radii = shape.GetRadii();
         var paint = new SKPaint
         {
-            Color = this.view.TrackColor.MultiplyAlpha(this.view.TrackOpacity).ToSKColor(),
-            IsAntialias = true,
+            Color = this.view.TrackColor.MultiplyAlpha(this.view.TrackOpacity).ToSKColor(), IsAntialias = true,
         };
         var path = new SKPath();
         var rect = new SKRoundRect();
@@ -56,10 +63,10 @@ internal class SwitchDrawable
         canvas.Save();
         var paint = new SKPaint
         {
-            Color = this.view.ThumbColor.MultiplyAlpha(this.view.ThumbOpacity).ToSKColor(),
-            IsAntialias = true,
+            Color = this.view.ThumbColor.MultiplyAlpha(this.view.ThumbOpacity).ToSKColor(), IsAntialias = true,
         };
-        var radius = this.view.IsChecked ? 8 + (4 * this.view.ChangingPercent) : 12 - (4 * this.view.ChangingPercent);
+
+        var radius = GetThumbRadius(8, 12, 14);
         canvas.DrawCircle(cx, cy, radius, paint);
         canvas.Restore();
     }
@@ -68,7 +75,8 @@ internal class SwitchDrawable
     {
         if (!this.view.IsChecked) return;
         canvas.Save();
-        var path = SKPath.ParseSvgPathData("M 5.8181543,10.027623 3.4153733,7.2675632 2.0000004,8.7537509 6.0066836,12.999999 14,4.5075 12.714286,3.0000004 Z");
+        var path = SKPath.ParseSvgPathData(
+            "M 5.8181543,10.027623 3.4153733,7.2675632 2.0000004,8.7537509 6.0066836,12.999999 14,4.5075 12.714286,3.0000004 Z");
         var matrix = new SKMatrix
         {
             ScaleX = this.view.ChangingPercent,
@@ -80,8 +88,7 @@ internal class SwitchDrawable
         path.Transform(matrix);
         var paint = new SKPaint
         {
-            Color = this.view.IconColor.MultiplyAlpha(this.view.IconOpacity).ToSKColor(),
-            IsAntialias = true,
+            Color = this.view.IconColor.MultiplyAlpha(this.view.IconOpacity).ToSKColor(), IsAntialias = true,
         };
         canvas.DrawPath(path, paint);
         canvas.Restore();
@@ -105,5 +112,93 @@ internal class SwitchDrawable
         var color = this.view.RippleColor;
         var point = new SKPoint(cx, cy);
         canvas.DrawRippleEffect(bounds, 0, this.view.RippleSize, point, color, this.view.RipplePercent, false);
+    }
+
+    /**
+     * Calculate the thumb's X position. Position is calculated based on the current state of the switch.
+     * And the current progress of the animation.
+     * @param lx The left position of the switch.
+     * @param rx The right position of the switch.
+     * @param offX The offset between the left and right position.
+     */
+    private float GetThumbX(float lx, float rx, float offX)
+    {
+        var isAnimating = this.view.ChangingPercent != 1.0;
+        float cx;
+
+        // If we are animating, we need to adjust the cx
+        if (this.view.IsChecked)
+            cx = isAnimating ? lx : rx;
+        else
+            cx = isAnimating ? rx : lx;
+
+        // Check if we are in the dead zone
+        var dz = this.view.ChangingPercent < 0.25 || this.view.ChangingPercent > 0.75;
+        if (!dz)
+        {
+            // Extract percentage when between 25% and 75% of animation
+            var percent = (this.view.ChangingPercent - 0.25f) / 0.5f;
+            cx = this.view.IsChecked
+                ? lx + (percent * offX)
+                : rx - (percent * offX);
+        }
+        else if (isAnimating)
+        {
+            // If we are in the dead zone and animating, we need to adjust the cx
+            // to the correct position
+            if (this.view.IsChecked)
+                cx = this.view.ChangingPercent < 0.25f ? lx : rx;
+            else
+                cx = this.view.ChangingPercent < 0.25f ? rx : lx;
+        }
+
+        return cx;
+    }
+
+    /**
+     * Calculate the thumb's radius. Radius is calculated based on the current state of the switch.
+     * And the current progress of the animation.
+     * @param leftSize This is the default size of the thumb when the switch is off.
+     * @param rightSize This is the default size of the thumb when the switch is on.
+     * @param moveSize This is the size of the thumb when the switch is moving.
+     */
+    private float GetThumbRadius(float leftSize, float rightSize, float moveSize)
+    {
+        var isAnimating = this.view.ChangingPercent != 1.0;
+        float radius;
+
+        // We need default size when we are not animating
+        if (this.view.IsChecked)
+            radius = isAnimating ? leftSize : rightSize;
+        else
+            radius = isAnimating ? rightSize : leftSize;
+
+        // Check if we are in the dead zone
+        var dz = this.view.ChangingPercent < 0.25 || this.view.ChangingPercent > 0.75;
+        if (!dz)
+        {
+            radius = moveSize;
+        }
+        else if (isAnimating)
+        {
+            // Current percent when we are in the dead zone
+            var percent = this.view.ChangingPercent < 0.25f
+                ? this.view.ChangingPercent / 0.25f
+                : (this.view.ChangingPercent - 0.75f) / 0.25f;
+
+            // If we are in the dead zone and animating, we need to adjust the radius
+            if (this.view.IsChecked)
+                // When we are animating to the right
+                radius = this.view.ChangingPercent < 0.25f
+                    ? leftSize.Lerp(moveSize, percent)
+                    : moveSize.Lerp(rightSize, percent);
+            else
+                // When we are animating to the left
+                radius = this.view.ChangingPercent < 0.25f
+                    ? rightSize.Lerp(moveSize, percent)
+                    : moveSize.Lerp(leftSize, percent);
+        }
+
+        return radius;
     }
 }


### PR DESCRIPTION
I took the liberty of updating an animation of a switch component and adding a new parameter `IsIconVisible` so that the user can enable/disable the Icon Checkmark.

[Video of animation from official Material 3 documentation](https://firebasestorage.googleapis.com/v0/b/design-spec/o/projects%2Fm3%2Fimages%2Fl1thrm3n-00_Article_Light-Dark_002.mp4?alt=media&token=fc6070c7-fd7b-4fdb-af33-b9de66906080)

[Updated animation](https://imgur.com/a/Ile7gFM)

As you can see I added a dead zone where Thumb is not moving but it will expand/retract it depends on which side the thumb currently is and on the parameter `IsChecked`. And after that, the thumb will move.
